### PR TITLE
Change link to href in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Share Dialog:
 
 	{
 		method: "share",
-		link: "http://example.com",
+		href: "http://example.com",
 		caption: "Such caption, very feed.",
 		description: "Much description",
 		picture: 'http://example.com/image.png'


### PR DESCRIPTION
The share dialog shows up if you use a `link` parameter, but the link is not there.

Thanks for the plugin!