### PR TITLE
Stop crashes when handleError is called

### DIFF
--- a/src/android/ConnectPlugin.java
+++ b/src/android/ConnectPlugin.java
@@ -721,7 +721,11 @@ public class ConnectPlugin extends CordovaPlugin {
             errMsg = "Dialog error: " + exception.getMessage();
         }
 
-        context.error(getErrorResponse(exception, errMsg, errorCode));
+        if (context != null) {
+            context.error(getErrorResponse(exception, errMsg, errorCode));
+        } else {
+            Log.e(TAG, "Error already sent so no context, msg: " + errMsg + ", code: " + errorCode);
+        }
     }
 
     private void makeGraphCall() {


### PR DESCRIPTION
When handleError is called without a context (this can happen when graphApi has invalid permissions), the plugin crashes. This logs the error rather than trying to send it back to the null context.