### PR TITLE
Updated share_open_graph method

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,13 +120,10 @@ Send Dialog:
 	
 Share dialog - post Open Graph Story:
 
-* "appnamespace" is the namespace of your facebook app (it can be found on the Settings page). It is needed only when you have a custom action/object.
-
 	{
-	
 		var obj = {};
 	
-    	obj['og:type'] = 'appnamespace:objectname';
+    	obj['og:type'] = 'objectname';
     	obj['og:title'] = 'Some title';
     	obj['og:url'] = 'https://en.wikipedia.org/wiki/Main_Page';
     	obj['og:description'] = 'Some description.';
@@ -137,11 +134,14 @@ Share dialog - post Open Graph Story:
     	
     	var options = {
     		method: 'share_open_graph', // Required
-        	action: 'appnamespace:action', // Required
+        	action: 'actionname', // Required
         	action_properties: JSON.stringify(ap), // Optional
         	object: JSON.stringify(obj) // Required
     	};
 	}
+	
+In case you want to use custom actions/objects, just prepend the app namespace to the name (E.g: ` obj['og:type'] = 'appnamespace:objectname' `, `action: 'appnamespace:actionname'`. The namespace of a Facebook app is found on the Settings page. 
+
 
 For options information see: [Facebook share dialog documentation](https://developers.facebook.com/docs/sharing/reference/share-dialog) [Facebook send dialog documentation](https://developers.facebook.com/docs/sharing/reference/send-dialog)
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Send Dialog:
 		picture: "http://example.com/image.png"
 	}
 	
-Share dialog - post Open Graph Story:
+Share dialog - Open Graph Story:
 
 	{
 		var obj = {};

--- a/README.md
+++ b/README.md
@@ -117,6 +117,31 @@ Send Dialog:
 		description: "The site I told you about",
 		picture: "http://example.com/image.png"
 	}
+	
+Share dialog - post Open Graph Story:
+
+* "appnamespace" is the namespace of your facebook app (it can be found on the Settings page). It is needed only when you have a custom action/object.
+
+	{
+	
+		var obj = {};
+	
+    	obj['og:type'] = 'appnamespace:objectname';
+    	obj['og:title'] = 'Some title';
+    	obj['og:url'] = 'https://en.wikipedia.org/wiki/Main_Page';
+    	obj['og:description'] = 'Some description.';
+
+    	var ap = {};
+    	
+    	ap['expires_in'] = 3600;
+    	
+    	var options = {
+    		method: 'share_open_graph', // Required
+        	action: 'appnamespace:action', // Required
+        	action_properties: JSON.stringify(ap), // Optional
+        	object: JSON.stringify(obj) // Required
+    	};
+	}
 
 For options information see: [Facebook share dialog documentation](https://developers.facebook.com/docs/sharing/reference/share-dialog) [Facebook send dialog documentation](https://developers.facebook.com/docs/sharing/reference/send-dialog)
 

--- a/src/android/ConnectPlugin.java
+++ b/src/android/ConnectPlugin.java
@@ -23,6 +23,7 @@ import com.facebook.share.ShareApi;
 import com.facebook.share.Sharer;
 import com.facebook.share.model.GameRequestContent;
 import com.facebook.share.model.ShareLinkContent;
+import com.facebook.share.model.ShareOpenGraphObject;
 import com.facebook.share.model.ShareOpenGraphAction;
 import com.facebook.share.model.ShareOpenGraphContent;
 import com.facebook.share.model.AppInviteContent;
@@ -379,7 +380,7 @@ public class ConnectPlugin extends CordovaPlugin {
         }
     }
 
-    private void executeDialog(JSONArray args, CallbackContext callbackContext) {
+    private void executeDialog(JSONArray args, CallbackContext callbackContext) throws JSONException {
         Map<String, String> params = new HashMap<String, String>();
         String method = null;
         JSONObject parameters;
@@ -476,17 +477,54 @@ public class ConnectPlugin extends CordovaPlugin {
             showDialogContext.sendPluginResult(pr);
 
             if (!params.containsKey("action")) {
-                callbackContext.error("Missing required parameter \"action\"");
+                callbackContext.error("Missing required parameter 'action'");
             }
-            ShareOpenGraphAction openGraphAction = new ShareOpenGraphAction.Builder()
-                    .setActionType(params.get("action"))
-                    .build();
+
+            if (!params.containsKey("object")) {
+                callbackContext.error("Missing required parameter 'object'.");
+            }
+
+            ShareOpenGraphObject.Builder objectBuilder = new ShareOpenGraphObject.Builder();
+            JSONObject jObject = new JSONObject(params.get("object"));
+
+            Iterator<?> objectKeys = jObject.keys();
+
+            String objectType = "";
+
+            while ( objectKeys.hasNext() ) {
+                String key = (String)objectKeys.next();
+                String value = jObject.getString(key);
+
+                objectBuilder.putString(key, value);
+
+                if (key.equals("og:type"))
+                    objectType = value;
+            }
+
+            if (objectType.equals("")) {
+                callbackContext.error("Missing required object parameter 'og:type'");
+            }
+
+            ShareOpenGraphAction.Builder actionBuilder = new ShareOpenGraphAction.Builder();
+            actionBuilder.setActionType(params.get("action"));
+
+            if (params.containsKey("action_properties")) {
+                JSONObject jActionProperties = new JSONObject(params.get("action_properties"));
+
+                Iterator<?> actionKeys = jActionProperties.keys();
+
+                while ( actionKeys.hasNext() ) {
+                    String actionKey = (String)actionKeys.next();
+
+                    actionBuilder.putString(actionKey, jActionProperties.getString(actionKey));
+                }
+            }
+
+            actionBuilder.putObject(objectType, objectBuilder.build());
 
             ShareOpenGraphContent.Builder content = new ShareOpenGraphContent.Builder()
-                    .setAction(openGraphAction);
-
-            if (params.containsKey("previewPropertyName"))
-                content.setPreviewPropertyName(params.get("previewPropertyName"));
+                    .setPreviewPropertyName(objectType)
+                    .setAction(actionBuilder.build());
 
             shareDialog.show(content.build());
 


### PR DESCRIPTION
Added objects and actions to the share open graph method. The options object that will be passed to the showDialog method will now be:

* **method**: share_open_graph - **required** 
* **action**: The facebook action to perform - **required**
* **action_properties**: A stringyfied JSON object that is made up of the action's properties. - optional
* **object**: A stringyfied JSON object that represents the facebook object. You must provide at least the 'og:type' property for this object. - **required**