### PR TITLE
Added ios and android method to manually activate app with facebook e…

### DIFF
--- a/src/android/ConnectPlugin.java
+++ b/src/android/ConnectPlugin.java
@@ -322,6 +322,15 @@ public class ConnectPlugin extends CordovaPlugin {
             executeAppInvite(args, callbackContext);
 
             return true;
+        } else if (action.equals("activateApp")) {
+            cordova.getThreadPool().execute(new Runnable() {
+                @Override
+                public void run() {
+                    AppEventsLogger.activateApp(cordova.getActivity());
+                }
+            });
+            
+            return true;
         }
         return false;
     }

--- a/src/ios/FacebookConnectPlugin.h
+++ b/src/ios/FacebookConnectPlugin.h
@@ -25,4 +25,5 @@
 - (void)graphApi:(CDVInvokedUrlCommand *)command;
 - (void)showDialog:(CDVInvokedUrlCommand *)command;
 - (void)appInvite:(CDVInvokedUrlCommand *) command;
+- (void)activateApp:(CDVInvokedUrlCommand *)command;
 @end

--- a/src/ios/FacebookConnectPlugin.m
+++ b/src/ios/FacebookConnectPlugin.m
@@ -433,6 +433,11 @@
 
 }
 
+- (void) activateApp:(CDVInvokedUrlCommand *)command
+{
+    [FBSDKAppEvents activateApp];
+}
+
 #pragma mark - Utility methods
 
 - (void) loginWithPermissions:(NSArray *)permissions withHandler:(FBSDKLoginManagerRequestTokenHandler) handler {

--- a/www/facebook-native.js
+++ b/www/facebook-native.js
@@ -46,3 +46,7 @@ exports.appInvite = function appLinks (options, s, f) {
   options = options || {}
   exec(s, f, 'FacebookConnectPlugin', 'appInvite', [options])
 }
+
+exports.activateApp = function (s, f) {
+  exec(s, f, 'FacebookConnectPlugin', 'activateApp', []);
+}


### PR DESCRIPTION
Added ios and android method to manually activate app with facebook events.

This is an enhancement we’ve added to our fork of the repo. Changes
copied from
https://github.com/Anu2g/cordova-plugin-facebook4/commit/cde6356bfedcd15
4ef1c29facaeeab273cc4ba7b.

Side note: I'm aware the guidelines say to PR to a branch called develop, but I wasn't able to select that.