### PR TITLE
Set up activity result callback before call show

### DIFF
--- a/src/android/ConnectPlugin.java
+++ b/src/android/ConnectPlugin.java
@@ -460,6 +460,9 @@ public class ConnectPlugin extends CordovaPlugin {
                 }
             }
 
+    		// Set up the activity result callback to this class
+			cordova.setActivityResultCallback(this);
+
             gameRequestDialog.show(builder.build());
 
         } else if (method.equalsIgnoreCase("share") || method.equalsIgnoreCase("feed")) {


### PR DESCRIPTION
Callback is called only once, when you call the show() for the first time.
It needs to be set up before call the function.