### PR TITLE
Set Facebook Android SDK version to 4.8

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -61,7 +61,7 @@
               android:label="@string/fb_app_name" />
         </config-file>
 
-        <framework src="com.facebook.android:facebook-android-sdk:4.+"/>
+        <framework src="com.facebook.android:facebook-android-sdk:4.8.+"/>
 
         <!-- cordova plugin src files -->
         <source-file src="src/android/ConnectPlugin.java" target-dir="src/org/apache/cordova/facebook" />


### PR DESCRIPTION
Fixes inability to compile when also using the push notifications plugin due to conflicts with Cardview which was introduced in version 4.9 of the Facebook Android SDK