### PR TITLE
Add share_open_graph to iOS (#173)

### DIFF
--- a/src/ios/FacebookConnectPlugin.m
+++ b/src/ios/FacebookConnectPlugin.m
@@ -252,7 +252,23 @@
         [FBSDKMessageDialog showWithContent:content delegate:self];
         return;
 
-    } else if ([method isEqualToString:@"share"] || [method isEqualToString:@"share_open_graph"] || [method isEqualToString:@"feed"]) {
+    } else if([method isEqualToString:@"share_open_graph"]) {
+        NSLog(@"Popping up open graph dialog");
+        
+        NSDictionary *properties = options[@"object"];
+        FBSDKShareOpenGraphObject *object = [FBSDKShareOpenGraphObject objectWithProperties:properties];
+        FBSDKShareOpenGraphAction *action = [[FBSDKShareOpenGraphAction alloc] init];
+        action.actionType = options[@"action"];
+        [action setObject:object forKey:properties[@"og:type"]];
+        FBSDKShareOpenGraphContent *content = [[FBSDKShareOpenGraphContent alloc] init];
+        content.action = action;
+        content.previewPropertyName = properties[@"og:type"];
+        
+        self.dialogCallbackId = command.callbackId;
+        [FBSDKShareDialog showFromViewController:[self topMostController] withContent:content delegate:self];
+        
+        return;
+    } else if ([method isEqualToString:@"share"] || [method isEqualToString:@"feed"]) {
         // Create native params
         FBSDKShareLinkContent *content = [[FBSDKShareLinkContent alloc] init];
         content.contentURL = [NSURL URLWithString:params[@"href"]];


### PR DESCRIPTION
I had a crack at this. It works the same as the Android version but I'm not sure why the dialog I'm getting is the browser one and not the native one. It's possible that it's the only one supported for Open Graph.

This should fix issue #173 