### PR TITLE
iOS: Added support for share Open Graph dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Send Dialog:
 		picture: "http://example.com/image.png"
 	}
 	
-Share dialog - Open Graph Story: (currently only available on Android, PRs welcome for iOS)
+Share dialog - Open Graph Story: (currently only fully available on Android, iOS currently does not support action_properties)
 
 	{
 		var obj = {};

--- a/src/ios/FacebookConnectPlugin.m
+++ b/src/ios/FacebookConnectPlugin.m
@@ -6,6 +6,7 @@
 //  Updated by Mathijs de Bruin on 11-08-25.
 //  Updated by Christine Abernathy on 13-01-22
 //  Updated by Jeduan Cornejo on 15-07-04
+//  Updated by Eds Keizer on 16-06-13
 //  Copyright 2011 Nitobi, Mathijs de Bruin. All rights reserved.
 //
 
@@ -252,7 +253,7 @@
         [FBSDKMessageDialog showWithContent:content delegate:self];
         return;
 
-    } else if ([method isEqualToString:@"share"] || [method isEqualToString:@"share_open_graph"] || [method isEqualToString:@"feed"]) {
+    } else if ([method isEqualToString:@"share"] || [method isEqualToString:@"feed"]) {
         // Create native params
         FBSDKShareLinkContent *content = [[FBSDKShareLinkContent alloc] init];
         content.contentURL = [NSURL URLWithString:params[@"href"]];
@@ -278,7 +279,45 @@
 
         [dialog show];
         return;
-    } else if ([method isEqualToString:@"apprequests"]) {
+    }
+    else if ( [method isEqualToString:@"share_open_graph"] ) {
+        if(!params[@"action"] || !params[@"object"]) {
+            NSLog(@"No action or object defined");
+            return;
+        }
+
+        //Get object JSON
+        NSError *jsonError;
+        NSData *objectData = [params[@"object"] dataUsingEncoding:NSUTF8StringEncoding];
+        NSDictionary *json = [NSJSONSerialization JSONObjectWithData:objectData
+                                                             options:NSJSONReadingMutableContainers
+                                                               error:&jsonError];
+        
+        if(jsonError) {
+            NSLog(@"There was an error parsing your 'object' JSON string");
+        } else {
+            FBSDKShareOpenGraphObject *object = [FBSDKShareOpenGraphObject objectWithProperties:json];
+            FBSDKShareOpenGraphAction *action = [[FBSDKShareOpenGraphAction alloc] init];
+            action.actionType = params[@"action"];
+            if(!json[@"og:type"]) {
+                NSLog(@"No 'og:type' encountered in the object JSON. Please provide an Open Graph object type.");
+                return;
+            }
+            NSString *objectType = json[@"og:type"];
+            objectType = [objectType stringByReplacingOccurrencesOfString:@"."
+                                                               withString:@":"];
+            
+            [action setObject:object forKey:objectType];
+            FBSDKShareOpenGraphContent *content = [[FBSDKShareOpenGraphContent alloc] init];
+            content.action = action;
+            content.previewPropertyName = objectType;
+            [FBSDKShareDialog showFromViewController:self.topMostController
+                                         withContent:content
+                                            delegate:nil];
+        }
+        return;
+    }
+    else if ([method isEqualToString:@"apprequests"]) {
         FBSDKGameRequestDialog *dialog = [[FBSDKGameRequestDialog alloc] init];
         dialog.delegate = self;
         if (![dialog canShow]) {


### PR DESCRIPTION
I added support for sharing Open Graph actions for iOS. The field action_properties is not supported yet.