### PR TITLE
Allow POST in api calls (iOS only)

### DIFF
--- a/src/ios/FacebookConnectPlugin.m
+++ b/src/ios/FacebookConnectPlugin.m
@@ -292,7 +292,7 @@
         NSDictionary *json = [NSJSONSerialization JSONObjectWithData:objectData
                                                              options:NSJSONReadingMutableContainers
                                                                error:&jsonError];
-        
+
         if(jsonError) {
             NSLog(@"There was an error parsing your 'object' JSON string");
         } else {
@@ -306,7 +306,7 @@
             NSString *objectType = json[@"og:type"];
             objectType = [objectType stringByReplacingOccurrencesOfString:@"."
                                                                withString:@":"];
-            
+
             [action setObject:object forKey:objectType];
             FBSDKShareOpenGraphContent *content = [[FBSDKShareOpenGraphContent alloc] init];
             content.action = action;
@@ -380,6 +380,15 @@
     NSArray *permissionsNeeded = [command argumentAtIndex:1];
     NSSet *currentPermissions = [FBSDKAccessToken currentAccessToken].permissions;
 
+    // POST arguments (could be nil)
+    NSString *httpMethod = [command argumentAtIndex:2];
+    NSMutableDictionary *params = [command argumentAtIndex:3];
+
+    // HTTP method GET by default
+    if (httpMethod == nil) {
+        httpMethod = @"GET";
+    }
+
     // We will store here the missing permissions that we will have to request
     NSMutableArray *requestPermissions = [[NSMutableArray alloc] initWithArray:@[]];
     NSArray *permissions;
@@ -410,7 +419,7 @@
     };
 
     NSLog(@"Graph Path = %@", graphPath);
-    FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc] initWithGraphPath:graphPath parameters:nil];
+    FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc] initWithGraphPath:graphPath parameters:params HTTPMethod:httpMethod];
 
     // If we have permissions to request
     if ([permissions count] == 0){
@@ -588,7 +597,7 @@
     [pairs enumerateObjectsUsingBlock:
      ^(NSString *pair, NSUInteger idx, BOOL *stop) {
          NSArray *kv = [pair componentsSeparatedByString:@"="];
-         
+
 #if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_9_0
          NSString *key = [kv[0] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
          NSString *val = [kv[1] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];

--- a/src/ios/FacebookConnectPlugin.m
+++ b/src/ios/FacebookConnectPlugin.m
@@ -149,7 +149,7 @@
     FBSDKLoginManagerRequestTokenHandler loginHandler = ^void(FBSDKLoginManagerLoginResult *result, NSError *error) {
         if (error) {
             // If the SDK has a message for the user, surface it.
-            NSString *errorMessage = error.userInfo[FBSDKErrorLocalizedDescriptionKey] ?: @"There was a problem logging you in.";
+            NSString *errorMessage = error.userInfo[FBSDKErrorDeveloperMessageKey] ?: @"There was a problem logging you in.";
             CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
                                                               messageAsString:errorMessage];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -406,7 +406,7 @@
     FBSDKGraphRequestHandler graphHandler = ^(FBSDKGraphRequestConnection *connection, id result, NSError *error) {
         CDVPluginResult* pluginResult;
         if (error) {
-            NSString *message = error.userInfo[FBSDKErrorLocalizedDescriptionKey] ?: @"There was an error making the graph call.";
+            NSString *message = error.userInfo[FBSDKErrorDeveloperMessageKey] ?: @"There was an error making the graph call.";
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
                                              messageAsString:message];
         } else {
@@ -430,7 +430,7 @@
     [self loginWithPermissions:requestPermissions withHandler:^(FBSDKLoginManagerLoginResult *result, NSError *error) {
         if (error) {
             // If the SDK has a message for the user, surface it.
-            NSString *errorMessage = error.userInfo[FBSDKErrorLocalizedDescriptionKey] ?: @"There was a problem logging you in.";
+            NSString *errorMessage = error.userInfo[FBSDKErrorDeveloperMessageKey] ?: @"There was a problem logging you in.";
             CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
                                                               messageAsString:errorMessage];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -531,7 +531,7 @@
     if (publishPermissionFound && readPermissionFound) {
         // Mix of permissions, not allowed
         NSDictionary *userInfo = @{
-            FBSDKErrorLocalizedDescriptionKey: @"Cannot ask for both read and publish permissions.",
+            FBSDKErrorDeveloperMessageKey: @"Cannot ask for both read and publish permissions.",
         };
         NSError *error = [NSError errorWithDomain:@"facebook" code:-1 userInfo:userInfo];
         handler(nil, error);
@@ -772,7 +772,7 @@
     NSLog(@"error::%@", error);
 
     CDVPluginResult* pluginResult;
-    NSString *message = error.userInfo[FBSDKErrorLocalizedDescriptionKey] ?: @"There was an error making the graph call.";
+    NSString *message = error.userInfo[FBSDKErrorDeveloperMessageKey] ?: @"There was an error making the graph call.";
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
                                      messageAsString:message];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:self.gameRequestDialogCallbackId];

--- a/www/facebook-native.js
+++ b/www/facebook-native.js
@@ -37,10 +37,25 @@ exports.logout = function logout (s, f) {
   exec(s, f, 'FacebookConnectPlugin', 'logout', [])
 }
 
-exports.api = function api (graphPath, permissions, s, f) {
-  permissions = permissions || []
-  exec(s, f, 'FacebookConnectPlugin', 'graphApi', [graphPath, permissions])
-}
+exports.api = function api (graphPath, permissions) {
+  var httpMethod, params, s, f;
+
+  permissions = permissions || [];
+
+  if (arguments[2] === 'POST') {
+    httpMethod = arguments[2];
+    params = arguments[3];
+    s = arguments[4];
+    f = arguments[5];
+
+    exec(s, f, 'FacebookConnectPlugin', 'graphApi', [graphPath, permissions, httpMethod, params]);
+  } else {
+    s = arguments[2];
+    f = arguments[3];
+
+    exec(s, f, 'FacebookConnectPlugin', 'graphApi', [graphPath, permissions]);
+  }
+};
 
 exports.appInvite = function appLinks (options, s, f) {
   options = options || {}


### PR DESCRIPTION
This implementation is based on JS SDK syntax. I do not have time to implement Android version, but shouldn't be that complicated.

Feed post example : 

``` js
facebookConnectPlugin.api(
    'me/feed',
    ['publish_actions'],
    'POST',
    {
        message: 'hello world'
    },
    function (response) {
        if (response && !response.error) {
            /* handle the result */
        }
    }
);
```
