### PR TITLE
Enable use of Promotional Text and Promotional Codes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,9 @@ Example options:
 
     {
       url: "http://example.com",
-      picture: "http://example.com/image.png"
+      picture: "http://example.com/image.png",
+      promotionText: "Enter some promo text here",
+      promotionCode: $scope.referral.mycode
     }
 
 ## Sample Code

--- a/src/android/ConnectPlugin.java
+++ b/src/android/ConnectPlugin.java
@@ -348,6 +348,9 @@ public class ConnectPlugin extends CordovaPlugin {
     private void executeAppInvite(JSONArray args, CallbackContext callbackContext) {
         String url = null;
         String picture = null;
+        String promotionCode = null;
+        String promotionText = null;
+        
         JSONObject parameters;
 
         try {
@@ -406,7 +409,7 @@ public class ConnectPlugin extends CordovaPlugin {
                 builder.setPreviewImageUrl(picture);
             }
             if (promotionText != null && promotionCode != null) {
-                builder.setPromotionDetails(promotionText, promotionCode)
+                builder.setPromotionDetails(promotionText, promotionCode);
             }
 
             showDialogContext = callbackContext;

--- a/src/android/ConnectPlugin.java
+++ b/src/android/ConnectPlugin.java
@@ -379,11 +379,34 @@ public class ConnectPlugin extends CordovaPlugin {
             }
         }
 
+        if (parameters.has("promotionText")) {
+            try {
+                promotionText = parameters.getString("promotionText");
+            } catch (JSONException e) {
+                Log.e(TAG, "Non-string 'promotionText' parameter provided to dialog");
+                callbackContext.error("Incorrect 'promotionText' parameter");
+                return;
+            }
+        }
+
+        if (parameters.has("promotionCode")) {
+            try {
+                promotionCode = parameters.getString("promotionCode");
+            } catch (JSONException e) {
+                Log.e(TAG, "Non-string 'promotionCode' parameter provided to dialog");
+                callbackContext.error("Incorrect 'promotionCode' parameter");
+                return;
+            }
+        }
+
         if (AppInviteDialog.canShow()) {
             AppInviteContent.Builder builder = new AppInviteContent.Builder();
             builder.setApplinkUrl(url);
             if (picture != null) {
                 builder.setPreviewImageUrl(picture);
+            }
+            if (promotionText != null && promotionCode != null) {
+                builder.setPromotionDetails(promotionText, promotionCode)
             }
 
             showDialogContext = callbackContext;

--- a/src/ios/FacebookConnectPlugin.m
+++ b/src/ios/FacebookConnectPlugin.m
@@ -459,6 +459,9 @@
     NSDictionary *options = [command.arguments objectAtIndex:0];
     NSString *url = options[@"url"];
     NSString *picture = options[@"picture"];
+    NSString *promotionText = options[@"promotionText"];
+    NSString *promotionCode = options[@"promotionCode"];
+    
     CDVPluginResult *result;
     self.dialogCallbackId = command.callbackId;
 
@@ -470,6 +473,13 @@
     if (picture) {
         content.appInvitePreviewImageURL = [NSURL URLWithString:picture];
     }
+
+    if (promotionText && promotionCode) {
+        content.promotionCode = promotionText;
+        content.promotionText = promotionCode;
+    }
+
+    
 
     FBSDKAppInviteDialog *dialog = [[FBSDKAppInviteDialog alloc] init];
     if ((url || picture) && [dialog canShow]) {

--- a/src/ios/FacebookConnectPlugin.m
+++ b/src/ios/FacebookConnectPlugin.m
@@ -475,8 +475,8 @@
     }
 
     if (promotionText && promotionCode) {
-        content.promotionCode = promotionText;
-        content.promotionText = promotionCode;
+        content.promotionCode = promotionCode;
+        content.promotionText = promotionText;
     }
 
     


### PR DESCRIPTION
Added the ability to use promotional text and promotional codes in facebook app invites. 

Promotional Text and Promotional Codes can be used be adding the optional parameters promotionalText and promotionalCode to the appInvite object. 

```
{
                url: "http://examle.co.uk/applink",
                picture: "http://cdn.examle.co.uk/logo.png",
                promotionText: "Test Promotion",
                promotionCode: "Test Code"
},
```
