### PR TITLE
Avoid FB prompt if required permission declined

### DIFF
--- a/src/android/ConnectPlugin.java
+++ b/src/android/ConnectPlugin.java
@@ -654,6 +654,7 @@ public class ConnectPlugin extends CordovaPlugin {
 
         if (declinedPermission != null) {
             graphContext.error("This request needs declined permission: " + declinedPermission);
+			return;
         }
 
         if (publishPermissions && readPermissions) {


### PR DESCRIPTION
This stops the handle if there is a permission declined error, when calling .api function (see #145 ). This way, if the user declines a required permission, the JS fail callback get called without showing the facebook prompt.

You can then handle the error manually by recalling, for example, the .login function.