### PR TITLE
Adding Facebook suffix for iOS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -18,6 +18,7 @@
 
     <preference name="APP_ID" />
     <preference name="APP_NAME" />
+    <preference name="URL_SCHEME" />
 
     <engines>
         <!-- Requires > 3.5.0 because of the custom Framework tag for iOS [CB-6698] -->
@@ -97,8 +98,8 @@
             <string>$APP_NAME</string>
         </config-file>
             
-        <config-file target="*-Info.plist" parent="FacebookUrlSchemeSuffix">
-            <string>stream</string>
+       <config-file target="*-Info.plist" parent="FacebookUrlSchemeSuffix">
+            <string>$URL_SCHEME</string>
         </config-file>
 
         <config-file target="*-Info.plist" parent="CFBundleURLTypes">
@@ -106,18 +107,7 @@
             <dict>
               <key>CFBundleURLSchemes</key>
               <array>
-                <string>fb$APP_IDstream</string>
-              </array>
-            </dict>
-          </array>
-        </config-file>
-
-        <config-file target="*-Info.plist" parent="CFBundleURLTypes">
-          <array>
-            <dict>
-              <key>CFBundleURLSchemes</key>
-              <array>
-                <string>fb$APP_ID</string>
+                <string>fb$APP_ID$URL_SCHEME</string>
               </array>
             </dict>
           </array>

--- a/plugin.xml
+++ b/plugin.xml
@@ -96,6 +96,21 @@
         <config-file target="*-Info.plist" parent="FacebookDisplayName">
             <string>$APP_NAME</string>
         </config-file>
+            
+        <config-file target="*-Info.plist" parent="FacebookUrlSchemeSuffix">
+            <string>stream</string>
+        </config-file>
+
+        <config-file target="*-Info.plist" parent="CFBundleURLTypes">
+          <array>
+            <dict>
+              <key>CFBundleURLSchemes</key>
+              <array>
+                <string>fb$APP_IDstream</string>
+              </array>
+            </dict>
+          </array>
+        </config-file>
 
         <config-file target="*-Info.plist" parent="CFBundleURLTypes">
           <array>


### PR DESCRIPTION
Adding Facebook suffix for correct redirect back to app if uses one facebook id for differents applications.