### PR TITLE
upgrade to the last facebook sdk + a fix

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -55,12 +55,11 @@
             <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/fb_app_id"/>
             <meta-data android:name="com.facebook.sdk.ApplicationName" android:value="@string/fb_app_name" />
             <activity android:name="com.facebook.FacebookActivity"
-              android:theme="@android:style/Theme.Translucent.NoTitleBar"
               android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
               android:label="@string/fb_app_name" />
         </config-file>
 
-        <framework src="com.facebook.android:facebook-android-sdk:4.14.+"/>
+        <framework src="com.facebook.android:facebook-android-sdk:4.+"/>
 
         <!-- cordova plugin src files -->
         <source-file src="src/android/ConnectPlugin.java" target-dir="src/org/apache/cordova/facebook" />


### PR DESCRIPTION
Fix the `Attribute activity#com.facebook.FacebookActivity@theme` error 

    Its better to just remove android:theme="@android:style/Theme.Translucent.NoTitleBar" from the <activity> xml tag since the latest Facebook SDK 4.16.1 already includes it.
source:  http://stackoverflow.com/a/39786339/1211174