### PR TITLE
Added hashtag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ Share Dialog:
 		href: "http://example.com",
 		caption: "Such caption, very feed.",
 		description: "Much description",
-		picture: 'http://example.com/image.png'
+		picture: 'http://example.com/image.png',
+		hashtag: '#myHashtag',
 		share_feedWeb: true, // iOS only
 	}
 

--- a/src/android/ConnectPlugin.java
+++ b/src/android/ConnectPlugin.java
@@ -595,8 +595,8 @@ public class ConnectPlugin extends CordovaPlugin {
                 builder.setImageUrl(Uri.parse(params.get("picture")));
             if(params.containsKey("description"))
                 builder.setContentDescription(params.get("description"));
-            if (paramBundle.containsKey("hashtag"))
-                builder.setShareHashtag(new ShareHashtag.Builder().setHashtag(paramBundle.get("hashtag")).build());
+            if (params.containsKey("hashtag"))
+                builder.setShareHashtag(new ShareHashtag.Builder().setHashtag(params.get("hashtag")).build());
 
             messageDialog.show(builder.build());
 

--- a/src/android/ConnectPlugin.java
+++ b/src/android/ConnectPlugin.java
@@ -595,8 +595,6 @@ public class ConnectPlugin extends CordovaPlugin {
                 builder.setImageUrl(Uri.parse(params.get("picture")));
             if(params.containsKey("description"))
                 builder.setContentDescription(params.get("description"));
-            if (params.containsKey("hashtag"))
-                builder.setShareHashtag(new ShareHashtag.Builder().setHashtag(params.get("hashtag")).build());
 
             messageDialog.show(builder.build());
 
@@ -806,6 +804,9 @@ public class ConnectPlugin extends CordovaPlugin {
             builder.setImageUrl(Uri.parse(paramBundle.get("picture")));
         if (paramBundle.containsKey("quote"))
             builder.setQuote(paramBundle.get("quote"));
+        if (paramBundle.containsKey("hashtag"))
+            builder.setShareHashtag(new ShareHashtag.Builder().setHashtag(paramBundle.get("hashtag")).build());
+
         return builder.build();
     }
 

--- a/src/android/ConnectPlugin.java
+++ b/src/android/ConnectPlugin.java
@@ -24,6 +24,7 @@ import com.facebook.login.LoginResult;
 import com.facebook.share.ShareApi;
 import com.facebook.share.Sharer;
 import com.facebook.share.model.GameRequestContent;
+import com.facebook.share.model.ShareHashtag;
 import com.facebook.share.model.ShareLinkContent;
 import com.facebook.share.model.ShareOpenGraphObject;
 import com.facebook.share.model.ShareOpenGraphAction;
@@ -594,6 +595,8 @@ public class ConnectPlugin extends CordovaPlugin {
                 builder.setImageUrl(Uri.parse(params.get("picture")));
             if(params.containsKey("description"))
                 builder.setContentDescription(params.get("description"));
+            if (paramBundle.containsKey("hashtag"))
+                builder.setShareHashtag(new ShareHashtag.Builder().setHashtag(paramBundle.get("hashtag")).build());
 
             messageDialog.show(builder.build());
 

--- a/src/ios/FacebookConnectPlugin.m
+++ b/src/ios/FacebookConnectPlugin.m
@@ -260,6 +260,7 @@
         content.contentTitle = params[@"caption"];
         content.imageURL = [NSURL URLWithString:params[@"picture"]];
         content.contentDescription = params[@"description"];
+        content.hashtag = [FBSDKHashtag hashtagWithString:[params objectForKey:@"hashtag"]];
         content.quote = params[@"quote"];
 
         self.dialogCallbackId = command.callbackId;


### PR DESCRIPTION
Just adds a hashtag if you specify the hashtag as an argument in the options objects for the share method.

*Ex.*
```
var options = {
                    method: "share",
                    href: "https://mysite.com",
                    hashtag: "#myHashtag"
                };

facebookConnectPlugin.showDialog(options, function(s){}, function(f){});
```