### PR TITLE
set loginBehavior to FBSDKLoginBehaviorSystemAccount

### DIFF
--- a/src/ios/FacebookConnectPlugin.m
+++ b/src/ios/FacebookConnectPlugin.m
@@ -182,6 +182,8 @@
         if (self.loginManager == nil) {
             self.loginManager = [[FBSDKLoginManager alloc] init];
         }
+        // set loginBehavior to SystemAccount
+        self.loginManager.loginBehavior = FBSDKLoginBehaviorSystemAccount;
         [self.loginManager logInWithReadPermissions:permissions fromViewController:[self topMostController] handler:loginHandler];
         return;
     }


### PR DESCRIPTION
set **loginBehavior** to **FBSDKLoginBehaviorSystemAccount**

Attempts log in through the Facebook account currently signed in through the device Settings. - note: If the account is not available to the app (either not configured by user or as determined by the SDK) this behavior falls back to \c FBSDKLoginBehaviorNative.

https://developers.facebook.com/docs/reference/iossdk/4.15.0/FBSDKLoginKit/enums/fbsdkloginbehavior.html/