### PR TITLE
Update plugin version in plugin.xml to 1.8.0

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-facebook4"
-        version="1.7.4">
+        version="1.8.0">
 
     <name>Facebook Connect</name>
 


### PR DESCRIPTION
Closes #458 

I am not sure if this will solve the issue of ensuring that this version https://www.npmjs.com/package/cordova-plugin-facebook4 matches the latest version on GitHub (1.8.0). If there is anything else that needs to be changed - please let me know.