### PR TITLE
Updated logPurchase to handle decimal values correctly.

### DIFF
--- a/src/android/ConnectPlugin.java
+++ b/src/android/ConnectPlugin.java
@@ -316,9 +316,21 @@ public class ConnectPlugin extends CordovaPlugin {
                 callbackContext.error("Invalid arguments");
                 return true;
             }
-            int value = args.getInt(0);
+            BigDecimal value;
+            if (args.get(0) instanceof Integer) {
+                value = BigDecimal.valueOf(args.getInt(0));
+            } else if (args.get(0) instanceof Long) {
+                value = BigDecimal.valueOf(args.getLong(0));
+            } else if (args.get(0) instanceof Double) {
+                value = BigDecimal.valueOf(args.getDouble(0));
+            } else if (args.get(0) instanceof String) {
+                value = new BigDecimal(args.getString(0));
+            } else {
+                callbackContext.error("logPurchase value invalid: " + args.get(0));
+                return false;
+            }
             String currency = args.getString(1);
-            logger.logPurchase(BigDecimal.valueOf(value), Currency.getInstance(currency));
+            logger.logPurchase(value, Currency.getInstance(currency));
             callbackContext.success();
             return true;
 

--- a/src/android/ConnectPlugin.java
+++ b/src/android/ConnectPlugin.java
@@ -316,19 +316,7 @@ public class ConnectPlugin extends CordovaPlugin {
                 callbackContext.error("Invalid arguments");
                 return true;
             }
-            BigDecimal value;
-            if (args.get(0) instanceof Integer) {
-                value = BigDecimal.valueOf(args.getInt(0));
-            } else if (args.get(0) instanceof Long) {
-                value = BigDecimal.valueOf(args.getLong(0));
-            } else if (args.get(0) instanceof Double) {
-                value = BigDecimal.valueOf(args.getDouble(0));
-            } else if (args.get(0) instanceof String) {
-                value = new BigDecimal(args.getString(0));
-            } else {
-                callbackContext.error("logPurchase value invalid: " + args.get(0));
-                return false;
-            }
+            BigDecimal value = new BigDecimal(args.getString(0));
             String currency = args.getString(1);
             logger.logPurchase(value, Currency.getInstance(currency));
             callbackContext.success();


### PR DESCRIPTION
Resolves issues #493. 

On Android (java) the logPurchase value parameter comes through as either Integer or Double depending on if the original js/ts number has a decimal. Updated logPurchase method to pull correct type out of args array (include Long & String as well).