### PR TITLE
Update plugin version in plugin.xml to 1.9.0

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-facebook4"
-        version="1.8.0">
+        version="1.9.0">
 
     <name>Facebook Connect</name>
 


### PR DESCRIPTION
It seems that the original PR https://github.com/jeduan/cordova-plugin-facebook4/pull/485 has broken the build process when installed via npm, as mentioned here:

Closes https://github.com/jeduan/cordova-plugin-facebook4/issues/497
Closes https://github.com/jeduan/cordova-plugin-facebook4/issues/506
Closes  https://github.com/jeduan/cordova-plugin-facebook4/issues/507

And the comment in https://github.com/jeduan/cordova-plugin-facebook4/issues/506#issuecomment-304539195 alerted me to the fact that it was probably caused by merging my previous PR which set to it to 1.8.0 when that was the latest version.

So hopefully merging this one change will fix it for everyone.