### PR TITLE
Fix for facebook-browser.js

### DIFF
--- a/www/facebook-browser.js
+++ b/www/facebook-browser.js
@@ -56,14 +56,27 @@ exports.login = function login (permissions, s, f) {
     options.scope = permissions.join(',')
   }
 
+  /**
+   * Functions that resolves or rejects a Promise depending on response.
+   *
+   * Cases:
+   * 1. Resolve/Success: If authResponse exists in response, that means that login is successful.
+   *    In that case resolve (success) function will be invoked with authResponse value.
+   * 2. Reject/Failure: In any other case (no response or response.authResponse) reject (failure) is invoked.
+   *  a. response exists and response.status exists, rejected with response.status.message.
+   *  b. response exists and response.status does not exist, rejected with response.
+   *  c. response does not exist, rejected with 'no response' message.
+   */
   FB.login(function (response) {
     if (response.authResponse) {
       s(response)
-    } else if (response.status) {
-      f(response.status.message)
-    } else if (response) {
-      f(response)
-    }  else {
+    } else if (response) { // Previously this was just an else statement.
+      if (response.status) { // When status is undefined this would throw an error, and rejection function would never be invoked.
+        f(response.status.message)
+      } else {
+        f(response)
+      }
+    } else { // In case that no response is available (e.g. popup dismissed)
       f('No response')
     } 
   }, options)

--- a/www/facebook-browser.js
+++ b/www/facebook-browser.js
@@ -59,9 +59,13 @@ exports.login = function login (permissions, s, f) {
   FB.login(function (response) {
     if (response.authResponse) {
       s(response)
-    } else {
+    } else if (response.status) {
       f(response.status.message)
-    }
+    } else if (response) {
+      f(response)
+    }  else {
+      f('No response')
+    } 
   }, options)
 }
 


### PR DESCRIPTION
Seems that there is unresolves/unrejected promise for FB.login function id response.status is null or undefined. This causes that promise is never resolved in consuming code.

For example, if you open loading popup before call it will not close on error if FB popup is just closed/dismissed.

Updated FB.login function to always have resolve/reject path.