### PR TITLE
Add support for Facebook push notifications

### DIFF
--- a/src/android/ConnectPlugin.java
+++ b/src/android/ConnectPlugin.java
@@ -304,7 +304,14 @@ public class ConnectPlugin extends CordovaPlugin {
             return true;
 
         } else if (action.equals("setPushNotificationsRegistrationId")) {
-            executeRegisterPushNotificationToken(args, callbackContext);
+            String token = args.getString(0);
+            try {
+                AppEventsLogger.setPushNotificationsRegistrationId(token);
+                callbackContext.success();
+            } catch (Exception e) {
+                Log.e("test", "Failed to register push notification token", e);
+                callbackContext.error("Failed to register push notification token");
+            }
             return true;
 
         } else if (action.equals("logEvent")) {
@@ -677,15 +684,6 @@ public class ConnectPlugin extends CordovaPlugin {
         } else {
             // Request new read permissions
             loginManager.logInWithReadPermissions(cordova.getActivity(), permissions);
-        }
-    }
-
-    private void executeRegisterPushNotificationToken(JSONArray args, CallbackContext callbackContext) throws JSONException {
-        String token = args.getString(0);
-        try {
-            AppEventsLogger.setPushNotificationsRegistrationId(token);
-        } catch (Exception e) {
-            Log.e("test", "Failed to complete token refresh", e);
         }
     }
 

--- a/src/android/ConnectPlugin.java
+++ b/src/android/ConnectPlugin.java
@@ -303,6 +303,10 @@ public class ConnectPlugin extends CordovaPlugin {
             }
             return true;
 
+        } else if (action.equals("setPushNotificationsRegistrationId")) {
+            executeRegisterPushNotificationToken(args, callbackContext);
+            return true;
+
         } else if (action.equals("logEvent")) {
             executeLogEvent(args, callbackContext);
             return true;
@@ -673,6 +677,15 @@ public class ConnectPlugin extends CordovaPlugin {
         } else {
             // Request new read permissions
             loginManager.logInWithReadPermissions(cordova.getActivity(), permissions);
+        }
+    }
+
+    private void executeRegisterPushNotificationToken(JSONArray args, CallbackContext callbackContext) throws JSONException {
+        String token = args.getString(0);
+        try {
+            AppEventsLogger.setPushNotificationsRegistrationId(token);
+        } catch (Exception e) {
+            Log.e("test", "Failed to complete token refresh", e);
         }
     }
 

--- a/www/facebook-native.js
+++ b/www/facebook-native.js
@@ -16,6 +16,15 @@ exports.checkHasCorrectPermissions = function checkHasCorrectPermissions (permis
   exec(s, f, 'FacebookConnectPlugin', 'checkHasCorrectPermissions', permissions)
 }
 
+exports.setPushNotificationsRegistrationId = function setPushNotificationsRegistrationId (token, s, f) {
+  // Added this function only to Android
+  if (token) {
+    exec(s, f, 'FacebookConnectPlugin', 'setPushNotificationsRegistrationId', [token])
+  } else {
+    f('Missing Argument: token')
+  }
+}
+
 exports.logEvent = function logEvent (name, params, valueToSum, s, f) {
   // Prevent NSNulls getting into iOS, messes up our [command.argument count]
   if (!params && !valueToSum) {


### PR DESCRIPTION
Allows you to register the app's FCM token with Facebook. This lets you use their push notification campaign manager to send push notifications to registered apps.