### PR TITLE
Fix for directory structure whatever cordova-android version.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -12,7 +12,7 @@
       The Facebook plugin for Apache Cordova allows you to use the same JavaScript code in your
       Cordova application as you use in your web application.
     </description>
-        
+
     <repo>https://github.com/jeduan/cordova-plugin-facebook4</repo>
 
     <license>Apache 2.0</license>
@@ -46,8 +46,7 @@
             <preference name="android-minSdkVersion" value="15" />
         </config-file>
 
-        <source-file src="src/android/facebookconnect.xml" target-dir="res/values" />
-        <config-file target="res/values/facebookconnect.xml" parent="/*">
+        <config-file target="res/values/strings.xml" parent="/resources">
             <string name="fb_app_id">$APP_ID</string>
             <string name="fb_app_name">$APP_NAME</string>
         </config-file>

--- a/scripts/after_prepare.js
+++ b/scripts/after_prepare.js
@@ -1,34 +1,35 @@
 #!/usr/bin/env node
-'use strict';
+'use strict'
 
-var fs = require('fs');
+var fs = require('fs')
 
-var getPreferenceValue = function(config, name) {
-    var value = config.match(new RegExp('name="' + name + '" value="(.*?)"', "i"))
-    if(value && value[1]) {
-        return value[1]
-    } else {
-        return null
-    }
+var getPreferenceValue = function (config, name) {
+  var value = config.match(new RegExp('name="' + name + '" value="(.*?)"', 'i'))
+  if (value && value[1]) {
+    return value[1]
+  } else {
+    return null
+  }
 }
 
-if(process.argv.join("|").indexOf("APP_ID=") > -1) {
-	var APP_ID = process.argv.join("|").match(/APP_ID=(.*?)(\||$)/)[1]
+var APP_ID
+if (process.argv.join('|').indexOf('APP_ID=') > -1) {
+  APP_ID = process.argv.join('|').match(/APP_ID=(.*?)(\||$)/)[1]
 } else {
-	var config = fs.readFileSync("config.xml").toString()
-	var APP_ID = getPreferenceValue(config, "APP_ID")
+  var config = fs.readFileSync('config.xml').toString()
+  APP_ID = getPreferenceValue(config, 'APP_ID')
 }
 
 var files = [
-    "platforms/browser/www/plugins/cordova-plugin-facebook4/www/facebook-browser.js",
-    "platforms/browser/platform_www/plugins/cordova-plugin-facebook4/www/facebook-browser.js",
-    "platforms/browser/www/cordova.js",
-    "platforms/browser/platform_www/cordova.js"
+  'platforms/browser/www/plugins/cordova-plugin-facebook4/www/facebook-browser.js',
+  'platforms/browser/platform_www/plugins/cordova-plugin-facebook4/www/facebook-browser.js',
+  'platforms/browser/www/cordova.js',
+  'platforms/browser/platform_www/cordova.js'
 ]
 
-for(var i in files) {
-    try {
-    	var contents = fs.readFileSync(files[i]).toString()
-	    fs.writeFileSync(files[i], contents.replace(/APP_ID/g, APP_ID))
-	} catch(err) {}
+for (var i in files) {
+  try {
+    var contents = fs.readFileSync(files[i]).toString()
+    fs.writeFileSync(files[i], contents.replace(/APP_ID/g, APP_ID))
+  } catch (err) {}
 }

--- a/src/android/facebookconnect.xml
+++ b/src/android/facebookconnect.xml
@@ -1,3 +1,0 @@
-<?xml version='1.0' encoding='utf-8'?>
-<resources>
-</resources>


### PR DESCRIPTION
Fixes #599
Update plugin.xml.
`<config-file>` interperts correctly path for AndroidManifest.xml, strings.xml and config.xml whatever version of directory structure.
I just remove facebookconnect.xml and move values inside strings.xml.

Tested with facebook connection under cordova-android-7.

note: Apply standardjs fixes on after_prepare.js too (sorry about that).
