### PR TITLE
Fix for #568 (Crash After Login second time)

### DIFF
--- a/src/android/ConnectPlugin.java
+++ b/src/android/ConnectPlugin.java
@@ -110,7 +110,7 @@ public class ConnectPlugin extends CordovaPlugin {
 
                         // If this login comes after doing a new permission request
                         // make the outstanding graph call
-                        if (lastGraphContext != null) {
+                        if (lastGraphContext != null && graphPath != null) {
                             makeGraphCall(lastGraphContext);
                             return;
                         }


### PR DESCRIPTION
Add null check for `graphPath` before `makeGraphCall()`.

The call to `makeGraphCall()` *requires* the `graphPath` string to not be null (it doesn't catch the NullPointerException), but it is always set to null when a graph call is completed.

Issue ref #568 