### PR TITLE
Add workaround for using setting strings in cordova-android 7.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The Facebook plugin for [Apache Cordova](http://cordova.apache.org/) allows you 
 ## Compatibility
 
   * Cordova >= 5.0.0
-  * cordova-android >= 4.0 (see Android Guide for cordova-android >= 7)
+  * cordova-android >= 4.0
   * cordova-ios >= 3.8
   * cordova-browser >= 3.6
   * Phonegap build (use phonegap-version >= cli-5.2.0, android-minSdkVersion>=15, and android-build-tool=gradle), see [example here](https://github.com/yoav-zibin/phonegap-tictactoe/blob/gh-pages/www/config.xml)

--- a/docs/android/README.md
+++ b/docs/android/README.md
@@ -29,15 +29,6 @@ You could add the property manually or specify it when you install the plugin, s
 
 Of course if you could, you could update your Cordova CLI and avoid specifying explicitly this option
 
-### cordova-android >= 7
-
-In order to install correctly this plugin for `cordova-android` v7.x.y and above, you have to specify the APP_ID and APP_NAME in the android `platform` tag of your `config.xml`
-
-    <config-file parent="/resources" target="./res/values/strings.xml">
-        <string name="fb_app_id">123456789</string>
-        <string name="fb_app_name">myApplication</string>
-    </config-file>
-
 ### In case of conflict
 
 If you would face version conflicts regarding the Facebook SDK with other plugins used in your project while installing `cordova-plugin-facebook4` for your ANDROID platform, you would be able to specify a specific Facebook SDK version for ANDROID using the variable `FACEBOOK_ANDROID_SDK_VERSION`

--- a/plugin.xml
+++ b/plugin.xml
@@ -48,7 +48,13 @@
         </config-file>
 
         <source-file src="src/android/facebookconnect.xml" target-dir="res/values" />
+        <!-- Used for cordova-android 6 -->
         <config-file target="res/values/facebookconnect.xml" parent="/*">
+            <string name="fb_app_id">$APP_ID</string>
+            <string name="fb_app_name">$APP_NAME</string>
+        </config-file>
+        <!-- Used for cordova-android 7 -->
+        <config-file target="app/src/main/res/values/facebookconnect.xml" parent="/*">
             <string name="fb_app_id">$APP_ID</string>
             <string name="fb_app_name">$APP_NAME</string>
         </config-file>


### PR DESCRIPTION
Looks like cordova-android 7 does not correctly prefix the target resource with `app/src/main/`.
This PR keeps the old correct target and adds another target that includes the full project path.