### PR TITLE
Prevent plugin from breaking cordova resume events

### DIFF
--- a/src/android/ConnectPlugin.java
+++ b/src/android/ConnectPlugin.java
@@ -92,9 +92,6 @@ public class ConnectPlugin extends CordovaPlugin {
         // augment web view to enable hybrid app events
         enableHybridAppEvents();
 
-        // Set up the activity result callback to this class
-        cordova.setActivityResultCallback(this);
-
         LoginManager.getInstance().registerCallback(callbackManager, new FacebookCallback<LoginResult>() {
             @Override
             public void onSuccess(final LoginResult loginResult) {


### PR DESCRIPTION
Without this fix, the cordova resume event on Android will never have it's pendingResult field set.  Other people seem to have fixed this problem by patching CordovaInterfaceImpl.java (links below) but I think it would be better to fix the Facebook plugin instead.

https://stackoverflow.com/questions/46867486/phonegap-cordova-camera-onresume-returns-empty-object
https://github.com/Wizcorp/phonegap-facebook-plugin/issues/1315