### PR TITLE
Update iOS and Android SDKs

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
     <preference name="APP_ID" />
     <preference name="APP_NAME" />
     <preference name="FACEBOOK_HYBRID_APP_EVENTS" default="false" />
-    <preference name="FACEBOOK_ANDROID_SDK_VERSION" default="5.2.0"/>
+    <preference name="FACEBOOK_ANDROID_SDK_VERSION" default="5.5.1"/>
 
     <engines>
         <!-- Requires > 3.5.0 because of the custom Framework tag for iOS [CB-6698] -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -166,9 +166,9 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="FBSDKCoreKit" spec="5.2.3"/>
-                <pod name="FBSDKLoginKit" spec="5.2.3"/>
-                <pod name="FBSDKShareKit" spec="5.2.3"/>
+                <pod name="FBSDKCoreKit" spec="5.6.0"/>
+                <pod name="FBSDKLoginKit" spec="5.6.0"/>
+                <pod name="FBSDKShareKit" spec="5.6.0"/>
             </pods>
         </podspec>
 


### PR DESCRIPTION
This PR updates both Facebook SDKs of iOS and Android.
- iOS version goes from 5.2.3 to 5.6.0 (version 5.7.0 isn't available on CocoaPods yet)
- Android version goes from 5.2.0 to 5.5.1

As stated in #802, the update of the iOS SDK fixes a bug with iOS 13 where the user is unable to login.