### PR TITLE
Updating to CocoaPods CDN

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -163,7 +163,7 @@
         <!-- Facebook SDK -->
         <podspec>
             <config>
-                <source url="https://github.com/CocoaPods/Specs.git"/>
+                <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods use-frameworks="true">
                 <pod name="FBSDKCoreKit" spec="5.7.0"/>


### PR DESCRIPTION
Reasons:
1.) https://blog.cocoapods.org/CocoaPods-1.7.2/

2.) If you have multiple plugins, what already use CDN, you get "multiple specifications" error when this plugin install pods during `ionic cordova platform add ios`
[!] Found multiple specifications for `Firebase (6.13.0)`
[!] Found multiple specifications for `FirebaseCoreDiagnostics (1.1.2)`
[!] Found multiple specifications for `GoogleUtilities (6.4.0)`
[!] Found multiple specifications for `AppAuth (1.1.0)`
etc...