### PR TITLE
Fix hasAccessToken check

### DIFF
--- a/src/android/ConnectPlugin.java
+++ b/src/android/ConnectPlugin.java
@@ -746,7 +746,12 @@ public class ConnectPlugin extends CordovaPlugin {
 
     // Simple active session check
     private boolean hasAccessToken() {
-        return AccessToken.getCurrentAccessToken() != null;
+        AccessToken token = AccessToken.getCurrentAccessToken();
+
+		if (token == null)
+			return false;
+
+		return !token.isExpired();
     }
 
     private void handleError(FacebookException exception, CallbackContext context) {


### PR DESCRIPTION
When an access token is expired this plugin would not
fetch a new one. This is invalid behaviour and resulted
in failed login attempts because the token was expired,
but still passed to the javascript code as a valid token.

This patch adds a check if the token is expired as well.