### PR TITLE
Fix Facebook login on iOS 13

### DIFF
--- a/src/ios/FacebookConnectPlugin.m
+++ b/src/ios/FacebookConnectPlugin.m
@@ -40,6 +40,10 @@
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(applicationDidBecomeActive:)
                                                  name:UIApplicationDidBecomeActiveNotification object:nil];
+
+        [[NSNotificationCenter defaultCenter] addObserver:self 
+                                             selector:@selector(handleOpenURLWithAppSourceAndAnnotation:) 
+                                                 name:CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification object:nil];
 }
 
 - (void) applicationDidFinishLaunching:(NSNotification *) notification {
@@ -58,6 +62,13 @@
         self.applicationWasActivated = YES;
         [self enableHybridAppEvents];
     }
+}
+
+- (void) handleOpenURLWithAppSourceAndAnnotation:(NSNotification *) notification {
+    NSMutableDictionary * options = [notification object];
+    NSURL* url = options[@"url"];
+
+    [[FBSDKApplicationDelegate sharedInstance] application:[UIApplication sharedApplication] openURL:url options:options];
 }
 
 #pragma mark - Cordova commands


### PR DESCRIPTION
Applied fix from here: https://github.com/jeduan/cordova-plugin-facebook4/issues/826
This fix works without problems on all iOS version.
It implements the code examples from Facebook in the plugin code, which makes additional docu or post scripts obsolete. 