### PR TITLE
disable AdvertiserIDCollectionEnabled and AutoLogAppEventsEnabled

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -65,6 +65,8 @@
         <config-file target="AndroidManifest.xml" parent="application">
             <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/fb_app_id"/>
             <meta-data android:name="com.facebook.sdk.ApplicationName" android:value="@string/fb_app_name" />
+            <meta-data android:name="com.facebook.sdk.AdvertiserIDCollectionEnabled" android:value="false" />
+            <meta-data android:name="com.facebook.sdk.AutoLogAppEventsEnabled" android:value="false" />
             <activity android:name="com.facebook.FacebookActivity"
               android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
               android:label="@string/fb_app_name" />
@@ -109,6 +111,14 @@
 
         <config-file target="*-Info.plist" parent="FacebookHybridAppEvents">
             <string>$FACEBOOK_HYBRID_APP_EVENTS</string>
+        </config-file>
+
+        <config-file parent="FacebookAutoLogAppEventsEnabled" target="*-Info.plist">
+            <false />
+        </config-file>
+
+        <config-file parent="FacebookAdvertiserIDCollectionEnabled" target="*-Info.plist">
+            <false />
         </config-file>
 
         <config-file target="*-Info.plist" parent="CFBundleURLTypes">


### PR DESCRIPTION
disable AdvertiserIDCollectionEnabled and AutoLogAppEventsEnabled turned on by default on android and ios to respect user privacy and prevent developer to violate RGPD French law and California Consumer Privacy Act unknowingly.

More information:
- https://developers.facebook.com/docs/app-events/getting-started-app-events-android  
- https://developers.facebook.com/docs/app-events/getting-started-app-events-ios

Externals reference for consequences of developer not turning the data collection off and not having proper privacy policy:
- https://www.theverge.com/2020/4/1/21202584/zoom-security-privacy-issues-video-conferencing-software-coronavirus-demand-response
- https://sfist.com/2020/04/01/zoom-video-conferencing-hit-with-privacy-scandal/
