### PR TITLE
move browser-specific hook to the browser section of plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -192,8 +192,9 @@
             <access origin="https://*.fbcdn.net" />
             <access origin="https://*.akamaihd.net" />
         </config-file>
+
+        <!-- after_prepare hook to populate APP_ID -->
+        <hook type="after_prepare" src="scripts/after_prepare.js" />
     </platform>
 
-    <!-- after_prepare hook to populate APP_ID -->
-    <hook type="after_prepare" src="scripts/after_prepare.js" />
 </plugin>


### PR DESCRIPTION
it isnt really necessary to run a cordova hook for all platforms when the hook is intended for browsers only.

this was previously mentioned in #356, but no action was taken by anyone