### PR TITLE
Add documentation for iOS/actionType

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Game request:
 		filters: 'app_non_users'
 	}
 
+Note: to have it working on `iOS` the `actionType` is required, see [issue#791](https://github.com/jeduan/cordova-plugin-facebook4/issues/791) for details.
+
 Send Dialog:
 
 	{


### PR DESCRIPTION
Improved documentation, due to [issue#791](https://github.com/jeduan/cordova-plugin-facebook4/issues/791)